### PR TITLE
[RFC] Memory management via memory pool

### DIFF
--- a/Arduino_Threads.h
+++ b/Arduino_Threads.h
@@ -42,9 +42,11 @@ class Shared // template definition
       return peek();
     }
   private:
+    static size_t constexpr QUEUE_SIZE = 16;
+
     T val;
-    rtos::MemoryPool<T, 16> memory_pool;
-    rtos::Queue<T, 16> queue;
+    rtos::MemoryPool<T, QUEUE_SIZE> memory_pool;
+    rtos::Queue<T, QUEUE_SIZE> queue;
 };
 
 #define CONCAT2(x,y) x##y


### PR DESCRIPTION
Actually `SharedPtr` as outlined in #4 isn't the best idea. mbed documentation itself suggests to pair up rtos::Queue with rtos::MemoryPool which is done in this PR.

@pnndra @facchinm 