### PR TITLE
Pin to last compatible action version in sketch compile workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -72,7 +72,9 @@ jobs:
           mv "${{ env.ARDUINOCORE_API_STAGING_PATH }}/api" "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino"
 
       - name: Compile examples
-        uses: arduino/compile-sketches@main
+        # Due to using obsolete JSON output keys and a non-semver version, the modified "arduino_threads" version of
+        # Arduino CLI is not compatible with any version of `arduino/compile-sketches` after this ref, thus the pin:
+        uses: arduino/compile-sketches@15d79dc244a7a19b8129a83d4d34c6ba44859f01
         with:
           cli-version: 'arduino_threads'
           fqbn: ${{ matrix.fqbn }}


### PR DESCRIPTION
This library requires a modified "arduino_threads" variant of [Arduino CLI](https://github.com/arduino/arduino-cli). Since the time that variant was made, there was a breaking change to the key names of Arduino CLI's JSON format output (https://github.com/arduino/arduino-cli/pull/1223). [The `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) uses some of the affected keys and so had to be updated to use the new keys (https://github.com/arduino/compile-sketches/pull/20). A translation system was put in place to provide backwards compatibility. However, this translation system requires that the Arduino CLI version specified via [the action's `cli-version` input](https://github.com/arduino/compile-sketches#cli-version) be [semver](https://semver.org/)-compliant so that it can determine whether it came before or after the breaking change.

The "arduino_threads" variant of Arduino CLI has the fatal combination of the old keys and non-semver version, meaning it is not compatible with versions of the `arduino/compile-sketches` action that came after the fix for the key name changes, which results in a spurious failure of the workflow runs.
For example:
https://github.com/bcmi-labs/Arduino_Threads/pull/19/checks?check_run_id=3674417845#step:6:198
```
Installing platform from path: extras/ArduinoCore-mbed
Traceback (most recent call last):
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 1717, in <module>
    main()  # pragma: no cover
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 56, in main
    compile_sketches.compile_sketches()
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 198, in compile_sketches
    self.install_platforms()
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 311, in install_platforms
    self.install_platforms_from_path(platform_list=platform_list.path)
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 493, in install_platforms_from_path
    platform_installation_path = self.get_platform_installation_path(platform=platform)
  File "/home/runner/work/_actions/arduino/compile-sketches/main/compilesketches/compilesketches.py", line 532, in get_platform_installation_path
    if installed_platform[self.cli_json_key("core list", "ID")] == platform[self.dependency_name_key]:
KeyError: 'id'
```

The workaround is to pin version of the `arduino/compile-sketches` action used in the "Compile Examples" workflow to [the
last compatible ref](https://github.com/arduino/compile-sketches/commit/15d79dc244a7a19b8129a83d4d34c6ba44859f01). Fortunately, that is quite recent in the action's revision history and none of [the changes that came since](https://github.com/arduino/compile-sketches/compare/b8a778ee3687121d17b80d6d6c442b9441a88aea...main) should be relevant for this application.