### PR TITLE
Use major version ref of `arduino/compile-sketches` action

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -80,9 +80,7 @@ jobs:
           mv "${{ env.ARDUINOCORE_API_STAGING_PATH }}/api" "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino"
 
       - name: Compile examples
-        # Due to using obsolete JSON output keys and a non-semver version, the modified "arduino_threads" version of
-        # Arduino CLI is not compatible with any version of `arduino/compile-sketches` after this ref, thus the pin:
-        uses: arduino/compile-sketches@15d79dc244a7a19b8129a83d4d34c6ba44859f01
+        uses: arduino/compile-sketches@v1
         with:
           cli-version: 'arduino_threads'
           fqbn: ${{ matrix.fqbn }}


### PR DESCRIPTION
The `arduino/compile-sketches` GitHub Actions action is used by the CI system to compile the library's example sketches
for each of the supported boards in order to provide a "smoke test". Previously, due to the use of an older modified
variant of Arduino CLI, a specific ref of the action had to be used (https://github.com/bcmi-labs/Arduino_Threads/pull/20). The variant of Arduino CLI has since been brought up to date, allowing it to be used with the current version of the action.

Use of the [major version ref](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management) will cause the workflow to use a stable version of the action while also benefit from
ongoing development to the action up until such time as a new major release of an action is made, at which time we would
need to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release
before updating the major ref (e.g., uses: `arduino/compile-sketches@v2`).