### PR TITLE
Group IO transfer code within utility function 'transfer_and_wait'.

### DIFF
--- a/examples/Threadsafe_IO/Threadsafe_SPI/Threadsafe_SPI.ino
+++ b/examples/Threadsafe_IO/Threadsafe_SPI/Threadsafe_SPI.ino
@@ -64,11 +64,7 @@ byte bmp388_read_reg(byte const reg_addr)
   byte read_write_buf[] = {static_cast<byte>(0x80 | reg_addr), 0, 0};
 
   IoRequest req(read_write_buf, sizeof(read_write_buf), nullptr, 0);
-  IoResponse rsp = bmp388.transfer(req);
-
-  /* Do other stuff */
-
-  rsp->wait();
+  IoResponse rsp = transfer_and_wait(bmp388, req);
 
   return read_write_buf[2];
 }

--- a/examples/Threadsafe_IO/Threadsafe_Wire/Threadsafe_Wire.ino
+++ b/examples/Threadsafe_IO/Threadsafe_Wire/Threadsafe_Wire.ino
@@ -45,7 +45,11 @@ void setup()
 
 void loop()
 {
-
+  /* If we don't hand back control then the main thread
+   * will hog the CPU and all other thread's won't get
+   * time to be executed.
+   */
+  rtos::ThisThread::yield();
 }
 
 /**************************************************************************************
@@ -61,11 +65,7 @@ byte lsm6dsox_read_reg(byte const reg_addr)
   byte read_buf  = 0;
   
   IoRequest  req(write_buf, read_buf);
-  IoResponse rsp = lsm6dsox.transfer(req);
-  
-  /* Optionally do other stuff */
-
-  rsp->wait();
+  IoResponse rsp = transfer_and_wait(lsm6dsox, req);
   
   return read_buf;
 }

--- a/src/Arduino_Threads.h
+++ b/src/Arduino_Threads.h
@@ -31,6 +31,7 @@
 #include "threading/Shared.hpp"
 
 #include "io/BusDevice.h"
+#include "io/util/util.h"
 #include "io/spi/SpiBusDevice.h"
 #include "io/wire/WireBusDevice.h"
 #include "io/serial/SerialDispatcher.h"

--- a/src/io/util/util.cpp
+++ b/src/io/util/util.cpp
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Arduino_ThreadsafeIO library.
+ * Copyright (c) 2021 Arduino SA.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include "util.h"
+
+/**************************************************************************************
+ * FUNCTION DEFINITION
+ **************************************************************************************/
+
+IoResponse transfer_and_wait(BusDevice & dev, IoRequest & req)
+{
+  IoResponse rsp = dev.transfer(req);
+  rsp->wait();
+  return rsp;
+}

--- a/src/io/util/util.h
+++ b/src/io/util/util.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the Arduino_ThreadsafeIO library.
+ * Copyright (c) 2021 Arduino SA.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef ARDUINO_THREADS_UTIL_H_
+#define ARDUINO_THREADS_UTIL_H_
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include "../BusDevice.h"
+#include "../IoTransaction.h"
+
+/**************************************************************************************
+ * FUNCTION DECLARATION
+ **************************************************************************************/
+
+IoResponse transfer_and_wait(BusDevice & dev, IoRequest & req);
+
+#endif /* ARDUINO_THREADS_UTIL_H_ */


### PR DESCRIPTION
This allows to write more compact code while still containing the same semantics