### PR TITLE
Revert "Bugfix: Yield after every execution of 'loop' if a loop delay of 0 is specified"

### DIFF
--- a/src/Arduino_Threads.cpp
+++ b/src/Arduino_Threads.cpp
@@ -118,17 +118,8 @@ void Arduino_Threads::threadFunc()
       }
     }
 
-    if (_loop_delay_ms) {
-      /* Sleep for the time we've been asked to insert between loops.
-      */
-      rtos::ThisThread::sleep_for(rtos::Kernel::Clock::duration_u32(_loop_delay_ms));
-    }
-    else
-    {
-      /* In any case yield here so that other threads can also be
-       * executed following the round-robin scheduling paradigm.
-       */
-      rtos::ThisThread::yield();
-    }
+    /* Sleep for the time we've been asked to insert between loops.
+     */
+    rtos::ThisThread::sleep_for(rtos::Kernel::Clock::duration_u32(_loop_delay_ms));
   }
 }


### PR DESCRIPTION
Reverts bcmi-labs/Arduino_Threads#38

We are using a [preemptive RTOS](https://os.mbed.com/docs/mbed-os/v6.9/program-setup/concepts.html) therefore each task is automatically interrupted and a context switch is performed after `time_slice` (in our case with a duration of 10 ms) is up.