### PR TITLE
[Martino/inot-as-class] Provide workarounds for typical sketch idioms not working when using inot-as-class model.

### DIFF
--- a/examples/Breaks_1/Thread.inot
+++ b/examples/Breaks_1/Thread.inot
@@ -1,0 +1,27 @@
+/* This fails to compile because it doesn't look like a
+ * declaration and a definition but rather like an attempt
+ * to overload myFunc with the same signature (again)
+ * resulting in a compile error.
+ */
+
+/* To fix this in the "class-wrapping" method, don't write
+ * forward declarations.
+ */
+
+//int myFunc(int const a, int const b);
+
+void setup()
+{
+
+}
+
+void loop()
+{
+  static int c = 0;
+  c += myFunc(0,c);
+}
+
+int myFunc(int const a, int const b)
+{
+  return (a + b);
+}

--- a/examples/Breaks_2/Thread.inot
+++ b/examples/Breaks_2/Thread.inot
@@ -1,0 +1,25 @@
+/* This fails to compile because myEventHandler has the
+ * function signature of 'void Thread::myEventHandler(void)'
+ * and is a member function of 'class Thread' while
+ * attachInterrupt expects a function with the signature
+ * 'void myEventHandler(void)'
+ */
+
+/* To fix this in the "class-wrapping" method, add `static`
+ * in front of the callback declaration.
+ */
+
+static void myEventHandler()
+{
+  /* Do something. */
+}
+
+void setup()
+{
+  attachInterrupt(digitalPinToInterrupt(2), myEventHandler, CHANGE);
+}
+
+void loop()
+{
+
+}

--- a/examples/Breaks_3/Thread.inot
+++ b/examples/Breaks_3/Thread.inot
@@ -1,0 +1,25 @@
+/* This fails to compile because in-class-initialisation of
+ * a static member variable is forbidden.
+ */
+
+/* To fix this in the "class-wrapping" method, remove `static`
+ * or remove the initialization.
+ */
+
+/*static*/ int my_global_variable = 0;
+
+#if ANOTHER_WAY
+static int my_global_variable;
+#endif
+
+void setup()
+{
+#if ANOTHER_WAY
+    // my_global_variable = 0;
+#endif
+}
+
+void loop()
+{
+
+}

--- a/examples/Breaks_4/Thread.inot
+++ b/examples/Breaks_4/Thread.inot
@@ -1,0 +1,54 @@
+/* Breaks for all kind of stuff ...
+ */
+
+/* To fix this in the "class-wrapping" method, remove `static`
+ * and change objects declarations
+ * from `Classname obj(args...)`
+ * to `Classname obj = Classname{args..}`
+ */
+
+/**************************************************************************************
+ * CONSTANTS
+ **************************************************************************************/
+
+static byte constexpr LSM6DSOX_ADDRESS      = 0x6A;
+static byte constexpr LSM6DSOX_WHO_AM_I_REG = 0x0F;
+
+/**************************************************************************************
+ * GLOBAL VARIABLES
+ **************************************************************************************/
+
+// BusDevice lsm6dsox(Wire, LSM6DSOX_ADDRESS);
+BusDevice lsm6dsox = BusDevice{Wire, LSM6DSOX_ADDRESS};
+
+/**************************************************************************************
+ * FUNCTIONS
+ **************************************************************************************/
+
+byte lsm6dsox_read_reg(byte reg_addr)
+{
+  byte read_buf = 0;
+  lsm6dsox.wire().write_then_read(&reg_addr, 1, &read_buf, 1);
+  return read_buf;
+}
+
+/**************************************************************************************
+ * SETUP/LOOP
+ **************************************************************************************/
+
+void setup()
+{
+  Serial.begin(9600);
+}
+
+void loop()
+{
+  /* Sleep between 5 and 500 ms */
+  rtos::ThisThread::sleep_for(rtos::Kernel::Clock::duration_u32(random(5,500)));
+  /* Try to read some data from the LSM6DSOX. */
+  byte const who_am_i = lsm6dsox_read_reg(LSM6DSOX_WHO_AM_I_REG);
+  /* Print thread id and chip id value to serial. */
+  char msg[64] = {0};
+  snprintf(msg, sizeof(msg), "%s: LSM6DSOX[WHO_AM_I] = 0x%X", rtos::ThisThread::get_name(), who_am_i);
+  Serial.println(msg);
+}

--- a/examples/Breaks_5/Thread.inot
+++ b/examples/Breaks_5/Thread.inot
@@ -1,0 +1,19 @@
+/* This fails to compile because myEventHandler is declared
+ * after setup/loop and currently there's not automatic prototype
+ * generation as done for the ino file.
+ */
+
+void setup()
+{
+  attachInterrupt(digitalPinToInterrupt(2), myEventHandler, CHANGE);
+}
+
+void loop()
+{
+
+}
+
+static void myEventHandler()
+{
+  /* Do something. */
+}

--- a/examples/Breaks_6/Thread.inot
+++ b/examples/Breaks_6/Thread.inot
@@ -1,0 +1,14 @@
+/* Break here is intentional
+ */
+
+void setup()
+{
+
+}
+
+void loop()
+{
+
+}
+
+int var = 0;


### PR DESCRIPTION
This provides a workaround for #43 .