### PR TITLE
Fix: Use only camel case for class member functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ As a result this interruption by the scheduler will break Wire I/O access for bo
 The mechanisms implemented in this library allow any thread to dispatch an I/O request asynchronously and either continue its operation or [yield](https://en.wikipedia.org/wiki/Yield_(multithreading)) control to the next scheduled thread. All I/O requests are stored in a queue and are executed within a high-priority I/O thread after a [context-switch](https://en.wikipedia.org/wiki/Context_switch). An example of this can be seen [here](examples/Threadsafe_IO/Threadsafe_SPI/Threadsafe_SPI.ino).
 
 ### :relieved: Convenient API
-Although you are free to directly manipulate I/O requests and responses (e.g. [Threadsafe_Wire](examples/Threadsafe_IO/Threadsafe_Wire/Threadsafe_Wire.ino)) there are convenient `read`/`write`/`write_then_read` abstractions inspired by the [Adafruit_BusIO](https://github.com/adafruit/Adafruit_BusIO) library (e.g. [Threadsafe_Wire_BusIO](examples/Threadsafe_IO/Threadsafe_Wire_BusIO/Threadsafe_Wire_BusIO.ino)).
+Although you are free to directly manipulate I/O requests and responses (e.g. [Threadsafe_Wire](examples/Threadsafe_IO/Threadsafe_Wire/Threadsafe_Wire.ino)) there are convenient `read`/`write`/`writeThenRead` abstractions inspired by the [Adafruit_BusIO](https://github.com/adafruit/Adafruit_BusIO) library (e.g. [Threadsafe_Wire_BusIO](examples/Threadsafe_IO/Threadsafe_Wire_BusIO/Threadsafe_Wire_BusIO.ino)).
 
 ## :zap: Caveats
 

--- a/docs/04-threadsafe-wire.md
+++ b/docs/04-threadsafe-wire.md
@@ -52,10 +52,10 @@ byte lsm6dsox_read_reg(byte const reg_addr)
 }
 ```
 
-### Synchronous thread-safe `Wire` access with `transfer_and_wait` 
+### Synchronous thread-safe `Wire` access with `transferAndWait` 
 ([`examples/Threadsafe_IO/Wire`](../examples/Threadsafe_IO/Wire))
 
-As the use of the `transfer` API might be difficult to grasp there's also a synchronous API call combining the request of the transfer and waiting for its result using `transfer_and_wait`. 
+As the use of the `transfer` API might be difficult to grasp there's also a synchronous API call combining the request of the transfer and waiting for its result using `transferAndWait`. 
 ```C++
 byte lsm6dsox_read_reg(byte const reg_addr)
 {
@@ -63,7 +63,7 @@ byte lsm6dsox_read_reg(byte const reg_addr)
   byte read_buffer  = 0;
   
   IoRequest  request(write_buffer, read_buffer);
-  IoResponse response = transfer_and_wait(lsm6dsox, request); /* Transmit IO request for execution and wait for completion of request. */
+  IoResponse response = transferAndWait(lsm6dsox, request); /* Transmit IO request for execution and wait for completion of request. */
   
   return read_buffer;
 }
@@ -78,7 +78,7 @@ For further simplification [Adafruit_BusIO](https://github.com/adafruit/Adafruit
 byte lsm6dsox_read_reg(byte reg_addr)
 {
   byte read_buffer = 0;
-  lsm6dsox.wire().write_then_read(&reg_addr, 1, &read_buffer, 1);
+  lsm6dsox.wire().writeThenRead(&reg_addr, 1, &read_buffer, 1);
   return read_buffer;
 }
 ```

--- a/docs/05-threadsafe-spi.md
+++ b/docs/05-threadsafe-spi.md
@@ -44,10 +44,10 @@ byte bmp388_read_reg(byte const reg_addr)
 }
 ```
 
-### Synchronous thread-safe `SPI` access with `transfer_and_wait` 
+### Synchronous thread-safe `SPI` access with `transferAndWait` 
 ([`examples/Threadsafe_IO/SPI`](../examples/Threadsafe_IO/SPI))
 
-As the use of the `transfer` API might be difficult to grasp there's also a synchronous API call combining the request of the transfer and waiting for its result using `transfer_and_wait`.
+As the use of the `transfer` API might be difficult to grasp there's also a synchronous API call combining the request of the transfer and waiting for its result using `transferAndWait`.
 ```C++
 byte bmp388_read_reg(byte const reg_addr)
 {
@@ -55,7 +55,7 @@ byte bmp388_read_reg(byte const reg_addr)
   byte read_write_buffer[] = {0x80 | reg_addr, 0, 0};
 
   IoRequest request(read_write_buffer, sizeof(read_write_buffer), nullptr, 0);
-  IoResponse response = transfer_and_wait(bmp388, request);
+  IoResponse response = transferAndWait(bmp388, request);
 
   auto value = read_write_buffer[2]; 
   return value;
@@ -74,7 +74,7 @@ byte bmp388_read_reg(byte const reg_addr)
   byte write_buffer[2] = {0x80 | reg_addr, 0};
   byte read_buffer = 0;
 
-  bmp388.spi().write_then_read(write_buffer, sizeof(write_buffer), &read_buffer, sizeof(read_buffer));
+  bmp388.spi().writeThenRead(write_buffer, sizeof(write_buffer), &read_buffer, sizeof(read_buffer));
   return read_buffer;
 }
 ```

--- a/examples/Breaks_4/Thread.inot
+++ b/examples/Breaks_4/Thread.inot
@@ -21,7 +21,7 @@ BusDevice lsm6dsox(Wire, LSM6DSOX_ADDRESS);
 byte lsm6dsox_read_reg(byte reg_addr)
 {
   byte read_buf = 0;
-  lsm6dsox.wire().write_then_read(&reg_addr, 1, &read_buf, 1);
+  lsm6dsox.wire().writeThenRead(&reg_addr, 1, &read_buf, 1);
   return read_buf;
 }
 

--- a/examples/Threadsafe_IO/SPI/SPI.ino
+++ b/examples/Threadsafe_IO/SPI/SPI.ino
@@ -70,7 +70,7 @@ byte bmp388_read_reg(byte const reg_addr)
   byte read_write_buf[] = {static_cast<byte>(0x80 | reg_addr), 0, 0};
 
   IoRequest req(read_write_buf, sizeof(read_write_buf), nullptr, 0);
-  IoResponse rsp = transfer_and_wait(bmp388, req);
+  IoResponse rsp = transferAndWait(bmp388, req);
 
   return read_write_buf[2];
 }

--- a/examples/Threadsafe_IO/SPI_BusIO/SPI_BusIO.ino
+++ b/examples/Threadsafe_IO/SPI_BusIO/SPI_BusIO.ino
@@ -4,7 +4,7 @@
  * with different client devices on the same SPI bus.
  *
  * This example uses Adafruit_BusIO style read(), write(),
- * write_then_read() APIs.
+ * writeThenRead() APIs.
  */
 
 /**************************************************************************************
@@ -70,7 +70,7 @@ byte bmp388_read_reg(byte const reg_addr)
   byte write_buf[2] = {static_cast<byte>(0x80 | reg_addr), 0};
   byte read_buf = 0;
 
-  bmp388.spi().write_then_read(write_buf, sizeof(write_buf), &read_buf, sizeof(read_buf));
+  bmp388.spi().writeThenRead(write_buf, sizeof(write_buf), &read_buf, sizeof(read_buf));
   return read_buf;
 }
 

--- a/examples/Threadsafe_IO/Serial_GlobalPrefixSuffix/Serial_GlobalPrefixSuffix.ino
+++ b/examples/Threadsafe_IO/Serial_GlobalPrefixSuffix/Serial_GlobalPrefixSuffix.ino
@@ -26,8 +26,8 @@ void setup()
   Serial.begin(9600);
   while (!Serial) { }
 
-  Serial.global_prefix(serial_log_message_prefix);
-  Serial.global_suffix(serial_log_message_suffix);
+  Serial.globalPrefix(serial_log_message_prefix);
+  Serial.globalSuffix(serial_log_message_suffix);
 
   Thread_1.start();
   Thread_2.start();

--- a/examples/Threadsafe_IO/Wire/Wire.ino
+++ b/examples/Threadsafe_IO/Wire/Wire.ino
@@ -67,7 +67,7 @@ byte lsm6dsox_read_reg(byte const reg_addr)
   byte read_buf  = 0;
   
   IoRequest  req(write_buf, read_buf);
-  IoResponse rsp = transfer_and_wait(lsm6dsox, req);
+  IoResponse rsp = transferAndWait(lsm6dsox, req);
   
   return read_buf;
 }

--- a/examples/Threadsafe_IO/Wire_BusIO/Wire_BusIO.ino
+++ b/examples/Threadsafe_IO/Wire_BusIO/Wire_BusIO.ino
@@ -4,7 +4,7 @@
  * with different client devices on the same Wire bus.
  *
  * This example uses Adafruit_BusIO style read(), write(),
- * write_then_read() APIs.
+ * writeThenRead() APIs.
  */
 
 /**************************************************************************************
@@ -64,7 +64,7 @@ void loop()
 byte lsm6dsox_read_reg(byte reg_addr)
 {
   byte read_buf = 0;
-  lsm6dsox.wire().write_then_read(&reg_addr, 1, &read_buf, 1);
+  lsm6dsox.wire().writeThenRead(&reg_addr, 1, &read_buf, 1);
   return read_buf;
 }
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -34,13 +34,14 @@ block	KEYWORD2
 unblock	KEYWORD2
 prefix	KEYWORD2
 suffix	KEYWORD2
-global_prefix	KEYWORD2
-global_suffix	KEYWORD2
+globalPrefix	KEYWORD2
+globalSuffix	KEYWORD2
 spi	KEYWORD2
 wire	KEYWORD2
 read	KEYWORD2
 write	KEYWORD2
-write_then_read	KEYWORD2
+writeThenRead	KEYWORD2
+transferAndWait	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/io/serial/SerialDispatcher.cpp
+++ b/src/io/serial/SerialDispatcher.cpp
@@ -202,13 +202,13 @@ void SerialDispatcher::suffix(SuffixInjectorCallbackFunc func)
   iter->suffix_func = func;
 }
 
-void SerialDispatcher::global_prefix(PrefixInjectorCallbackFunc func)
+void SerialDispatcher::globalPrefix(PrefixInjectorCallbackFunc func)
 {
   mbed::ScopedLock<rtos::Mutex> lock(_mutex);
   _global_prefix_callback = func;
 }
 
-void SerialDispatcher::global_suffix(SuffixInjectorCallbackFunc func)
+void SerialDispatcher::globalSuffix(SuffixInjectorCallbackFunc func)
 {
   mbed::ScopedLock<rtos::Mutex> lock(_mutex);
   _global_suffix_callback = func;

--- a/src/io/serial/SerialDispatcher.h
+++ b/src/io/serial/SerialDispatcher.h
@@ -63,8 +63,8 @@ public:
   typedef std::function<String(String const &, String const &)>  SuffixInjectorCallbackFunc;
   void prefix(PrefixInjectorCallbackFunc func);
   void suffix(SuffixInjectorCallbackFunc func);
-  void global_prefix(PrefixInjectorCallbackFunc func);
-  void global_suffix(SuffixInjectorCallbackFunc func);
+  void globalPrefix(PrefixInjectorCallbackFunc func);
+  void globalSuffix(SuffixInjectorCallbackFunc func);
 
 
 private:

--- a/src/io/spi/SpiBusDevice.cpp
+++ b/src/io/spi/SpiBusDevice.cpp
@@ -45,7 +45,7 @@ IoResponse SpiBusDevice::transfer(IoRequest & req)
 
 bool SpiBusDevice::read(uint8_t * buffer, size_t len, uint8_t sendvalue)
 {
-  SpiBusDeviceConfig config(_config.spi(), _config.settings(), _config.select_func(), _config.deselect_func(), sendvalue);
+  SpiBusDeviceConfig config(_config.spi(), _config.settings(), _config.selectFunc(), _config.deselectFunc(), sendvalue);
   IoRequest req(nullptr, 0, buffer, len);
   IoResponse rsp = SpiDispatcher::instance().dispatch(&req, &config);
   rsp->wait();
@@ -60,9 +60,9 @@ bool SpiBusDevice::write(uint8_t * buffer, size_t len)
   return true;
 }
 
-bool SpiBusDevice::write_then_read(uint8_t * write_buffer, size_t write_len, uint8_t * read_buffer, size_t read_len, uint8_t sendvalue)
+bool SpiBusDevice::writeThenRead(uint8_t * write_buffer, size_t write_len, uint8_t * read_buffer, size_t read_len, uint8_t sendvalue)
 {
-  SpiBusDeviceConfig config(_config.spi(), _config.settings(), _config.select_func(), _config.deselect_func(), sendvalue);
+  SpiBusDeviceConfig config(_config.spi(), _config.settings(), _config.selectFunc(), _config.deselectFunc(), sendvalue);
   IoRequest req(write_buffer, write_len, read_buffer, read_len);
   IoResponse rsp = SpiDispatcher::instance().dispatch(&req, &config);
   rsp->wait();

--- a/src/io/spi/SpiBusDevice.h
+++ b/src/io/spi/SpiBusDevice.h
@@ -44,7 +44,7 @@ public:
 
   bool read(uint8_t * buffer, size_t len, uint8_t sendvalue = 0xFF);
   bool write(uint8_t * buffer, size_t len);
-  bool write_then_read(uint8_t * write_buffer, size_t write_len, uint8_t * read_buffer, size_t read_len, uint8_t sendvalue = 0xFF);
+  bool writeThenRead(uint8_t * write_buffer, size_t write_len, uint8_t * read_buffer, size_t read_len, uint8_t sendvalue = 0xFF);
 
 
 private:

--- a/src/io/spi/SpiBusDeviceConfig.h
+++ b/src/io/spi/SpiBusDeviceConfig.h
@@ -64,10 +64,10 @@ public:
   SPISettings settings   () const { return _spi_settings; }
   void        select     () const { if (_spi_select) _spi_select(); }
   void        deselect   () const { if (_spi_deselect) _spi_deselect(); }
-  byte        fill_symbol() const { return _fill_symbol; }
+  byte        fillSymbol () const { return _fill_symbol; }
 
-  SpiSelectFunc   select_func  () const { return _spi_select;  }
-  SpiDeselectFunc deselect_func() const { return _spi_deselect;  }
+  SpiSelectFunc   selectFunc  () const { return _spi_select;  }
+  SpiDeselectFunc deselectFunc() const { return _spi_deselect;  }
 
 private:
 

--- a/src/io/spi/SpiDispatcher.cpp
+++ b/src/io/spi/SpiDispatcher.cpp
@@ -158,7 +158,7 @@ void SpiDispatcher::processSpiIoRequest(SpiIoTransaction * spi_io_transaction)
   size_t bytes_received = 0;
   for(; bytes_received < io_request->bytes_to_read; bytes_received++)
   {
-    uint8_t const tx_byte = config->fill_symbol();
+    uint8_t const tx_byte = config->fillSymbol();
     uint8_t const rx_byte = config->spi().transfer(tx_byte);
 
     io_request->read_buf[bytes_received] = rx_byte;

--- a/src/io/util/util.cpp
+++ b/src/io/util/util.cpp
@@ -26,7 +26,7 @@
  * FUNCTION DEFINITION
  **************************************************************************************/
 
-IoResponse transfer_and_wait(BusDevice & dev, IoRequest & req)
+IoResponse transferAndWait(BusDevice & dev, IoRequest & req)
 {
   IoResponse rsp = dev.transfer(req);
   rsp->wait();

--- a/src/io/util/util.h
+++ b/src/io/util/util.h
@@ -30,6 +30,6 @@
  * FUNCTION DECLARATION
  **************************************************************************************/
 
-IoResponse transfer_and_wait(BusDevice & dev, IoRequest & req);
+IoResponse transferAndWait(BusDevice & dev, IoRequest & req);
 
 #endif /* ARDUINO_THREADS_UTIL_H_ */

--- a/src/io/wire/WireBusDevice.cpp
+++ b/src/io/wire/WireBusDevice.cpp
@@ -45,7 +45,7 @@ IoResponse WireBusDevice::transfer(IoRequest & req)
 
 bool WireBusDevice::read(uint8_t * buffer, size_t len, bool stop)
 {
-  WireBusDeviceConfig config(_config.wire(), _config.slave_addr(), _config.restart(), stop);
+  WireBusDeviceConfig config(_config.wire(), _config.slaveAddr(), _config.restart(), stop);
   IoRequest req(nullptr, 0, buffer, len);
   IoResponse rsp = WireDispatcher::instance().dispatch(&req, &config);
   rsp->wait();
@@ -55,20 +55,20 @@ bool WireBusDevice::read(uint8_t * buffer, size_t len, bool stop)
 bool WireBusDevice::write(uint8_t * buffer, size_t len, bool stop)
 {
   bool const restart = !stop;
-  WireBusDeviceConfig config(_config.wire(), _config.slave_addr(), restart, _config.stop());
+  WireBusDeviceConfig config(_config.wire(), _config.slaveAddr(), restart, _config.stop());
   IoRequest req(buffer, len, nullptr, 0);
   IoResponse rsp = WireDispatcher::instance().dispatch(&req, &config);
   rsp->wait();
   return true;
 }
 
-bool WireBusDevice::write_then_read(uint8_t * write_buffer, size_t write_len, uint8_t * read_buffer, size_t read_len, bool stop)
+bool WireBusDevice::writeThenRead(uint8_t * write_buffer, size_t write_len, uint8_t * read_buffer, size_t read_len, bool stop)
 {
   /* Copy the Wire parameters from the device and modify only those
    * which can be modified via the parameters of this function.
    */
   bool const restart = !stop;
-  WireBusDeviceConfig config(_config.wire(), _config.slave_addr(), restart, _config.stop());
+  WireBusDeviceConfig config(_config.wire(), _config.slaveAddr(), restart, _config.stop());
   /* Fire off the IO request and await its response. */
   IoRequest req(write_buffer, write_len, read_buffer, read_len);
   IoResponse rsp = WireDispatcher::instance().dispatch(&req, &config);

--- a/src/io/wire/WireBusDevice.h
+++ b/src/io/wire/WireBusDevice.h
@@ -44,7 +44,7 @@ public:
 
   bool read(uint8_t * buffer, size_t len, bool stop = true);
   bool write(uint8_t * buffer, size_t len, bool stop = true);
-  bool write_then_read(uint8_t * write_buffer, size_t write_len, uint8_t * read_buffer, size_t read_len, bool stop = false);
+  bool writeThenRead(uint8_t * write_buffer, size_t write_len, uint8_t * read_buffer, size_t read_len, bool stop = false);
 
 
 private:

--- a/src/io/wire/WireBusDeviceConfig.h
+++ b/src/io/wire/WireBusDeviceConfig.h
@@ -44,7 +44,7 @@ public:
 
 
   inline arduino::HardwareI2C & wire() { return _wire; }
-  inline byte slave_addr() const { return _slave_addr; }
+  inline byte slaveAddr()  const { return _slave_addr; }
   inline bool restart()    const { return _restart; }
   inline bool stop()       const { return _stop; }
 

--- a/src/io/wire/WireDispatcher.cpp
+++ b/src/io/wire/WireDispatcher.cpp
@@ -138,7 +138,7 @@ void WireDispatcher::processWireIoRequest(WireIoTransaction * wire_io_transactio
 
   if (io_request->bytes_to_write > 0)
   {
-    config->wire().beginTransmission(config->slave_addr());
+    config->wire().beginTransmission(config->slaveAddr());
 
     size_t bytes_written = 0;
     for (; bytes_written < io_request->bytes_to_write; bytes_written++)
@@ -155,7 +155,7 @@ void WireDispatcher::processWireIoRequest(WireIoTransaction * wire_io_transactio
 
   if (io_request->bytes_to_read > 0)
   {
-    config->wire().requestFrom(config->slave_addr(), io_request->bytes_to_read, config->stop());
+    config->wire().requestFrom(config->slaveAddr(), io_request->bytes_to_read, config->stop());
 
     while(config->wire().available() != static_cast<int>(io_request->bytes_to_read))
     {


### PR DESCRIPTION
This fixes #63.