### PR TITLE
Shared/Sink/Source: remove operator overloaded API

### DIFF
--- a/src/threading/Shared.hpp
+++ b/src/threading/Shared.hpp
@@ -44,9 +44,6 @@ public:
   void push(T const & val);
   inline T peek() const { return _val; }
 
-  operator T() [[deprecated("Use 'pop()' instead.")]];
-  void operator = (T const & val) [[deprecated("Use 'push()' instead.")]];
-
 private:
 
   T _val;
@@ -92,18 +89,6 @@ void Shared<T,QUEUE_SIZE>::push(T const & val)
     *val_ptr = val;
     _mailbox.put(val_ptr);
   }
-}
-
-template<class T, size_t QUEUE_SIZE>
-Shared<T,QUEUE_SIZE>::operator T()
-{
-  return pop();
-}
-
-template<class T, size_t QUEUE_SIZE>
-void Shared<T,QUEUE_SIZE>::operator = (T const & val)
-{
-  push(val);
 }
 
 #endif /* ARDUINO_THREADS_SHARED_HPP_ */

--- a/src/threading/Sink.hpp
+++ b/src/threading/Sink.hpp
@@ -40,11 +40,6 @@ public:
 
   virtual T pop() = 0;
   virtual void inject(T const & value) = 0;
-
-  inline operator T() [[deprecated("Use 'pop()' instead.")]]
-  {
-    return pop();
-  }
 };
 
 template<typename T>

--- a/src/threading/Source.hpp
+++ b/src/threading/Source.hpp
@@ -45,8 +45,6 @@ public:
   void connectTo(SinkBase<T> & sink);
   void push(T const & val);
 
-  void operator = (T const & val) [[deprecated("Use 'push()' instead.")]];
-
 private:
   std::list<SinkBase<T> *> _sink_list;
 };
@@ -70,12 +68,6 @@ void Source<T>::push(T const & val)
                 {
                   sink->inject(val);
                 });
-}
-
-template<typename T>
-void Source<T>::operator = (T const & val)
-{
-  push(val);
 }
 
 #endif /* ARDUINO_THREADS_SOURCE_HPP_ */


### PR DESCRIPTION
No more assignment operator, type operator.

This leads to less confusion as discussed in #67.

Due to being a single-commit/single-PR it can be easily reverted at a later point-in-time, should doing so become desirable.