### PR TITLE
Update check-arduino action after library has been added to the index.

### DIFF
--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -23,6 +23,6 @@ jobs:
         with:
           compliance: specification
           # Change this to "update" once the library is added to the index.
-          library-manager: submit
+          library-manager: update
           # Always use this setting for official repositories. Remove for 3rd party projects.
           official: true


### PR DESCRIPTION
See https://github.com/arduino/library-registry/pull/1624 .