### PR TITLE
Correct Portenta H7 FQBN in "Compile Examples" workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -51,10 +51,10 @@ jobs:
           - fqbn: arduino:mbed_nano:nanorp2040connect
             platforms: |
               - name: arduino:mbed_nano
-          - fqbn: arduino:mbed_portenta:envie_m4
+          - fqbn: arduino:mbed_portenta:envie_m7:target_core=cm4
             platforms: |
               - name: arduino:mbed_portenta
-          - fqbn: arduino:mbed_portenta:envie_m7
+          - fqbn: arduino:mbed_portenta:envie_m7:target_core=cm7
             platforms: |
               - name: arduino:mbed_portenta
 


### PR DESCRIPTION
The `arduino:mbed_portenta:envie_m4` board definition has been removed from the `arduino:mbed_portenta` platform. The GitHub Actions workflow's continued use of the non-existent FQBN caused a spurious run failure of the job that covers using the library on the M4 core of the Portenta H7 board:

https://github.com/arduino-libraries/Arduino_Threads/actions/runs/5320038086/jobs/9633283538#step:6:289

```text
Error during build: Error resolving FQBN: board arduino:mbed_portenta@4.0.2:envie_m4 not found
```

The target core is now configured by a [custom board option](https://arduino.github.io/arduino-cli/latest/platform-specification/#custom-board-options) of the `arduino:mbed_portenta:envie_m7` board definition. The FQBN in the workflow are here updated to use that board option.