### PR TITLE
Configure size deltas report for public repository

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -104,24 +104,3 @@ jobs:
           name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-
-  report-size-deltas:
-    needs: compile-test
-    # Run even if some compilations failed.
-    if: always() && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download sketches reports artifact
-        id: download-artifact
-        continue-on-error: true # If compilation failed for all boards then there are no artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
-
-      - name: Comment size deltas report to PR
-        uses: arduino/report-size-deltas@v1
-        # If actions/download-artifact failed, there are no artifacts to report from.
-        if: steps.download-artifact.outcome == 'success'
-        with:
-          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,29 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.ya?ml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  report:
+    # Scheduled workflow runs would cause excess GitHub Actions service charges in a private repo
+    if: github.repository_visibility == 'public'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports


### PR DESCRIPTION
This repository uses the "arduino/report-size-deltas" GitHub Actions action to cause a report to be commented to pull request threads of the change in the memory usage of the example sketches caused by the changes proposed in the pull request.

This system was set up during the initial development of the library, when the repository was private. The configuration was [specially tailored for use in a private repository](https://github.com/per1234/.github/blob/main/workflow-templates/compile-examples-private.md). Since that time, the repository has been made public, which has implications for the configuration of this report system.

In order to make this comment, the GitHub Actions workflow must have write permissions in the repository. The "Compile Examples" workflow will not have these permissions when it is triggered by a pull request from a fork. This causes the "report-size-deltas" job of the workflow to fail:

https://github.com/arduino-libraries/Arduino_Threads/actions/runs/5323101288/jobs/9640663125?pr=95#step:4:12

```text
WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
WARNING:__main__:Temporarily unable to open URL (HTTP Error 403: Forbidden), retrying
Traceback (most recent call last):
  File "/reportsizedeltas/reportsizedeltas.py", line 797, in <module>
    main()  # pragma: no cover
    ^^^^^^
  File "/reportsizedeltas/reportsizedeltas.py", line [32](https://github.com/arduino-libraries/Arduino_Threads/actions/runs/5323101288/jobs/9640663125?pr=95#step:4:33), in main
    report_size_deltas.report_size_deltas()
  File "/reportsizedeltas/reportsizedeltas.py", line 92, in report_size_deltas
    self.report_size_deltas_from_local_reports()
  File "/reportsizedeltas/reportsizedeltas.py", line 109, in report_size_deltas_from_local_reports
    self.comment_report(pr_number=pr_number, report_markdown=report)
  File "/reportsizedeltas/reportsizedeltas.py", line 537, in comment_report
    self.http_request(url=url, data=report_data)
  File "/reportsizedeltas/reportsizedeltas.py", line 601, in http_request
    with self.raw_http_request(url=url, data=data) as response_object:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/reportsizedeltas/reportsizedeltas.py", line 636, in raw_http_request
    raise TimeoutError("Maximum number of URL load retries exceeded")
TimeoutError: Maximum number of URL load retries exceeded
```

For this reason, there [a different configuration of the report system](https://github.com/per1234/.github/blob/main/workflow-templates/report-size-deltas.md) is used in public repositories. The alternative configuration uses a dedicated workflow to produce the report. That workflow is triggered on a schedule rather than by the pull request event. That gives it the required write permissions in the repository.
