### PR TITLE
Fix typos in documentation

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -68,22 +68,22 @@ jobs:
 
       # it's necessary to checkout the platform before installing it so that the ArduinoCore-API dependency can be added
       - name: Checkout ArduinoCore-mbed
-        # this step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
+        # this step only needed when the Arduino Mbed OS Boards platform sourced from the repository is being used
         uses: actions/checkout@v4
         with:
           repository: arduino/ArduinoCore-mbed
-          # the arduino/actions/libraries/compile-examples action will install the platform from this path
+          # the arduino/compile-sketches action will install the platform from this path
           path: ${{ env.ARDUINOCORE_MBED_STAGING_PATH }}
 
       - name: Checkout ArduinoCore-API
-        # this step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
+        # this step only needed when the Arduino Mbed OS Boards platform sourced from the repository is being used
         uses: actions/checkout@v4
         with:
           repository: arduino/ArduinoCore-API
           path: ${{ env.ARDUINOCORE_API_STAGING_PATH }}
 
       - name: Install ArduinoCore-API
-        # this step only needed when the Arduino mbed-Enabled Boards platform sourced from the repository is being used
+        # this step only needed when the Arduino Mbed OS Boards platform sourced from the repository is being used
         run: |
           mv "${{ env.ARDUINOCORE_API_STAGING_PATH }}/api" "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino"
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Check Arduino status](https://github.com/arduino-libraries/Arduino_Threads/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_Threads/actions/workflows/check-arduino.yml)
 [![Spell Check status](https://github.com/arduino-libraries/Arduino_Threads/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/Arduino_Threads/actions/workflows/spell-check.yml)
 
-This library makes it easy to use the multi-threading capability of [Arduino](https://www.arduino.cc/) boards that use an [Mbed OS](https://os.mbed.com/docs/mbed-os/latest/introduction/index.html)-based core library. Additionally this library provides thread-safe access to `Wire`, `SPI` and `Serial` which is relevant when creating multi-threaded sketches in order to avoid common pitfalls such as race-conditions and invalid state. ​
+This library makes it easy to use the multi-threading capability of [Arduino](https://www.arduino.cc/) boards that use an [Mbed OS](https://os.mbed.com/docs/mbed-os/latest/introduction/index.html)-based core library. Additionally this library provides thread-safe access to `Wire`, `SPI` and `Serial` which is relevant when creating multi-threaded sketches in order to avoid common pitfalls such as race-conditions and invalid state.
 
-Preeliminary **documentation** and download links for **required tooling** are available within the [`/docs`](docs/README.md) subfolder.
+Preliminary **documentation** and download links for **required tooling** are available within the [`/docs`](docs/README.md) subfolder.
 
 ## :star: Features
 ### :thread: Multi-threaded sketch execution

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 `Arduino_Threads/docs`
 ======================
-The Arduino threading APIs brings multi-threading to the world of Arduino. If you're new to the concept of threads we suggest you have first a look at the [Threading Basics](threading-basics.md) document.
+The Arduino threading APIs bring multi-threading to the world of Arduino. If you're new to the concept of threads we suggest you first take a look at the [Threading Basics](threading-basics.md) document.
 
 The following Arduino architectures and boards are currently supported:
 * `mbed_portenta`: [Portenta H7](https://store.arduino.cc/products/portenta-h7)

--- a/docs/cli-getting-started.md
+++ b/docs/cli-getting-started.md
@@ -3,23 +3,23 @@
 How to get started with the `Arduino CLI` and `Arduino_Threads`
 ===============================================================
 ## Introduction
-For now, you need to use the Arduino CLI to upload sketches made with the `Arduino_Threads` library. It can be intimidating at first, but once you get the hang of it, it is not that different from working in the IDE. 
+For now, you need to use the Arduino CLI to upload sketches made with the `Arduino_Threads` library. It can be intimidating at first, but once you get the hang of it, it is not that different from working in the IDE.
 
-This document will help you get started, showing you how to find all the information you need to get off the ground without needing to go in depth and learn everything there is to know about the CLI. 
+This document will help you get started, showing you how to find all the information you need to get off the ground without needing to go in depth and learn everything there is to know about the CLI.
 
-## Installing 
-To use the `Arduino_Threads` library, a special version of the Arduino CLI needs to be downloaded and installed. Installing the Arduino CLI is really just as simple as downloading it and extracting the files from the .zip archive, once it is on your computer it is installed. However, to keep your workflow tidy and organized, we recommend moving it to a directory with a short path. If you have been using the Arduino IDE, most likely the files are stored in your `Documents` folder, so let's put the CLI files in the same place. 
+## Installing
+To use the `Arduino_Threads` library, a special version of the Arduino CLI needs to be downloaded and installed. Installing the Arduino CLI is really just as simple as downloading it and extracting the files from the .zip archive, once it is on your computer it is installed. However, to keep your workflow tidy and organized, we recommend moving it to a directory with a short path. If you have been using the Arduino IDE, most likely the files are stored in your `Documents` folder, so let's put the CLI files in the same place.
 
-Make a new folder in your `Documents` folder, and name it `CLI`, extract the files from the .zip archive to this folder. 
+Make a new folder in your `Documents` folder, and name it `CLI`, extract the files from the .zip archive to this folder.
 
 ## Navigating With the Command Prompt and Launching the Arduino CLI
-Since the Arduino CLI is a command line tool, it is not a program that you can launch by double clicking on the `.exe` file. Instead, we need to start it from the command prompt. Using the command prompt can be thought of like using the file explorer, you are in a folder, can move around to other folders, create new files, delete files, etc. The difference is that you do all of these things with commands instead of buttons. 
+Since the Arduino CLI is a command line tool, it is not a program that you can launch by double clicking on the `.exe` file. Instead, we need to start it from the command prompt. Using the command prompt can be thought of like using the file explorer, you are in a folder, can move around to other folders, create new files, delete files, etc. The difference is that you do all of these things with commands instead of buttons.
 
-Unlike the file explorer where you click the folder you want to go to, navigating in the command prompt is done by first writing the command letting the program know that we want to move somewhere new, then telling it where we want to go. 
+Unlike the file explorer where you click the folder you want to go to, navigating in the command prompt is done by first writing the command letting the program know that we want to move somewhere new, then telling it where we want to go.
 
 When you open up a command prompt window, you should be started in the root directory of your user profile, you can see in what folder you are by looking at the path text right where you enter your commands. Because you're started at the root of your user profile, the path should say `C:\Users\<your name>`
 
-Inside of this root folder there are other folders, if you want to go into the `Documents` folder, instead of clicking on it like you would do in the file explorer, you write the command: 
+Inside of this root folder there are other folders, if you want to go into the `Documents` folder, instead of clicking on it like you would do in the file explorer, you write the command:
 ```
 cd Documents
 ```
@@ -32,7 +32,7 @@ If you want to go back one step, to the folder you came from, you write this com
 ```
 cd ..
 ```
-But we don't need to do that now, we want to be inside of the `CLI` folder, that is inside of the `Documents` folder. 
+But we don't need to do that now, we want to be inside of the `CLI` folder, that is inside of the `Documents` folder.
 
 Navigate to it with the command:
 ```
@@ -61,11 +61,11 @@ To compile sketches and to upload to your Arduino board, you need to know some i
 ```
 arduino-cli board list
 ```
-If your board was found, you will get a bunch of information about it. The information we're interested in is the `FQBN`, and the port. `FQBN` stands for "Fully Qualified Board Name", and is how the computer refers to the board. The port is like an address for the board. 
+If your board was found, you will get a bunch of information about it. The information we're interested in is the `FQBN`, and the port. `FQBN` stands for "Fully Qualified Board Name", and is how the computer refers to the board. The port is like an address for the board.
 
 ![Board list](./assets/boardlist.png)
 
-If you are, like we are, using an Arduino Nano 33 BLE Sense, the `FQBN` will be `arduino:mbed_nano:nano33ble`. We need to specify every time we are compiling and uploading sketches that they are to be compiled for this board, just like we do in the IDE. 
+If you are, like we are, using an Arduino Nano 33 BLE Sense, the `FQBN` will be `arduino:mbed_nano:nano33ble`. We need to specify every time we are compiling and uploading sketches that they are to be compiled for this board, just like we do in the IDE.
 
 ## Installing Cores
 If you have already used your Arduino board with the IDE, you can skip this step entirely. Otherwise, there are some files you may need to install to be able to use the board. But don't worry, it's just one command. The Arduino Nano 33 BLE Sense uses the `arduino:mbed_nano` core, which is another piece of information that we got from the board list command we executed, so we need to install that before using the board.
@@ -79,7 +79,7 @@ arduino-cli core install arduino:mbed_nano
 If you are using a board with another core, replace `arduino:mbed_nano` in the command with whatever core you got from the board list.
 
 ## Make a Sketch
-Now it is time to either make a new sketch, or to place a sketch that you have already made or want to test in the `CLI` folder. 
+Now it is time to either make a new sketch, or to place a sketch that you have already made or want to test in the `CLI` folder.
 
 If you want to make a new sketch, use the command:
 ```
@@ -87,15 +87,15 @@ arduino-cli sketch new MySketch
 ```
 and a new folder will be created inside of the `CLI` folder, this new folder is named `MySketch` and contains a file named `MySketch.ino`. This .ino file can be opened, and edited in your text-editor of choice. Once you are happy with the sketch, move on to the next step.
 
-If you already have a sketch that you want to upload, find it and move it into the `CLI` folder. Be sure to move the folder containing the `.ino` file and any extra files included in the sketch, and not the `.ino` file on its own. 
+If you already have a sketch that you want to upload, find it and move it into the `CLI` folder. Be sure to move the folder containing the `.ino` file and any extra files included in the sketch, and not the `.ino` file on its own.
 
 ## Compile and Upload
 
 The final steps to do are to compile and to upload the sketch. We'll do this with two separate commands. To compile, we need to pass the FQBN in the command to specify what board we want to compile it for, and we need to tell it what sketch we want to compile. We'll compile the sketch we created earlier to be uploaded to an Arduino Nano 33 BLE Sense. We can do this with the command:
 ```
-arduino-cli compile --fqbn arduino:mbed_nano:nano33ble MySketch 
-``` 
-Once you execute this command, it's going to start compiling unless something went wrong. If it looks like nothing is happening - Great! That probably means that everything is going as it should. Depending on the core, compiling might take a few minutes. Be patient, it may seem like it's taking too long, but give it time. Eventually, you'll get a statement about the memory use, libraries included, and platform used. 
+arduino-cli compile --fqbn arduino:mbed_nano:nano33ble MySketch
+```
+Once you execute this command, it's going to start compiling unless something went wrong. If it looks like nothing is happening - Great! That probably means that everything is going as it should. Depending on the core, compiling might take a few minutes. Be patient, it may seem like it's taking too long, but give it time. Eventually, you'll get a statement about the memory use, libraries included, and platform used.
 
 ![Compiled sketch statement](./assets/compiled.png)
 
@@ -103,7 +103,7 @@ Now that the sketch is compiled, let's upload it! For this, we need to specify t
 ```
 arduino-cli upload -p COM14 --fqbn arduino:mbed_nano:nano33ble MySketch
 ```
-If everything went as it should, the sketch is now uploading to the board, and once that is done, you've successfully used the Arduino CLI to upload a sketch to your board. 
+If everything went as it should, the sketch is now uploading to the board, and once that is done, you've successfully used the Arduino CLI to upload a sketch to your board.
 
 ![Uploaded sketch](./assets/uploaded.png)
 

--- a/docs/threading-basics.md
+++ b/docs/threading-basics.md
@@ -3,7 +3,7 @@
 Threading Basics
 ================
 ## Introduction
-Threading is a concept that is used on many operating systems to run tasks in parallel. An Arduino example of two such tasks could be to read the position of a potentiometer knob while controlling a servo motor to follow that position. Running such tasks in parallel is also called multitasking. 
+Threading is a concept that is used on many operating systems to run tasks in parallel. An Arduino example of two such tasks could be to read the position of a potentiometer knob while controlling a servo motor to follow that position. Running such tasks in parallel is also called multitasking.
 
 Previously Arduino sketches didn't support the concept of multitasking, unless you took specific measures to support it. With this so called single-threaded approach instructions in your Arduino sketch are executed sequentially one by one. If an instruction or a function call respectively makes the runtime environment wait for its execution to complete, it's called a "blocking" function. You may have encountered the limitations of this when interacting with multiple sensors and actuators at once. For example if you let a servo motor react to the data read from a potentiometer as mentioned above. While the servo motor is moving to its target position no further reading of the potentiometer can be done because the program waits until the servo is done moving. To solve this issue multitasking can be used which allows to "simultaneously" execute multiple task such as reading from a sensor and controlling a motor. In the context of multitasking a thread is basically a mechanism (provided usually by the operating system) to encapsulate a task to be run concurrently with others.
 

--- a/docs/threadsafe-serial.md
+++ b/docs/threadsafe-serial.md
@@ -5,7 +5,7 @@ Thread-safe `Serial`
 ## Introduction
 While both `SPI` and `Wire` are communication protocols which explicitly exist to facilitate communication between one server device and multiple client devices there are no such considerations for the `Serial` interface. `Serial` communication usually exists in a one-to-one mapping between two communication partners of equal power (both can initiate communication on their own right, there is no server/client relationship).
 
-One example would be an Arduino sketch sending AT commands to a modem over a Serial connection and interpreting the result of those commands. Another example would be a GPS unit sending NMEA encoded location data to the Arduino for parsing. In both cases the only sensible software representation for such functionality (AT command module or NMEA message parser) is a single thread. Also in both cases it is undesirable for other threads to inject other kind of data into the serial communication as this would only confuse i.e. the AT controlled modem which reads that data. 
+One example would be an Arduino sketch sending AT commands to a modem over a Serial connection and interpreting the result of those commands. Another example would be a GPS unit sending NMEA encoded location data to the Arduino for parsing. In both cases the only sensible software representation for such functionality (AT command module or NMEA message parser) is a single thread. Also in both cases it is undesirable for other threads to inject other kind of data into the serial communication as this would only confuse i.e. the AT controlled modem which reads that data.
 
 A good example for multiple threads writing to `Serial` would be logging where mixing messages from different sources doesn't cause any harm. A possible example for multiple threads reading from `Serial` would be to i.e. split an NMEA parser across multiple threads, i.e. one thread only parses RMC-messages, another parses GGA-messages, etc. In any case the thread-safe `Serial` supports both single-writer/single-reader and multiple-write/multiple-reader scenarios.
 
@@ -48,7 +48,7 @@ Serial.println(counter);
 ### Prevent message break-up using `block()`/`unblock()`
 ([`examples/Threadsafe_IO/Serial_Writer`](../examples/Threadsafe_IO/Serial_Writer))
 
-Due to the pre-emptive nature of the underlying mbed-os threading mechanism a multi-line sequence of `Serial.print/println()` could be interrupted at any point in time. When multiple threads are writing to the same Serial interface, this can lead to jumbled-up messages.
+Due to the preemptive nature of the underlying mbed-os threading mechanism a multi-line sequence of `Serial.print/println()` could be interrupted at any point in time. When multiple threads are writing to the same Serial interface, this can lead to jumbled-up messages.
 
 ```C++
 /* Thread_1.inot */

--- a/docs/threadsafe-spi.md
+++ b/docs/threadsafe-spi.md
@@ -25,7 +25,7 @@ BusDevice bmp388(SPI, DEVICE_CS_PIN, spi_clock, spi_bit_order, spi_bit_mode);
 BusDevice bmp388(SPI, device_cs_select, device_cs_deselect, spi_settings);
 ```
 
-### Asynchronous thread-safe `SPI` access with `transfer`/`wait` 
+### Asynchronous thread-safe `SPI` access with `transfer`/`wait`
 Once a `BusDevice` is declared it can be used to transfer data to and from the peripheral by means of the `transfer()` API. As opposed to the traditional Arduino bus APIs, `transfer()` is asynchronous and thus won't block execution unless the `wait()` function is called.
 Note that we are in a parallel programming environment which means that calls to `transfer()` on the same bus from different sketches will be arbitrated.
 
@@ -39,12 +39,12 @@ byte bmp388_read_reg(byte const reg_addr)
   IoResponse response = bmp388.transfer(request);
   /* Do other stuff */
   response->wait(); /* Wait for the completion of the IO Request. */
-  auto value = read_write_buffer[2]; 
+  auto value = read_write_buffer[2];
   return value;
 }
 ```
 
-### Synchronous thread-safe `SPI` access with `transferAndWait` 
+### Synchronous thread-safe `SPI` access with `transferAndWait`
 ([`examples/Threadsafe_IO/SPI`](../examples/Threadsafe_IO/SPI))
 
 As the use of the `transfer` API might be difficult to grasp there's also a synchronous API call combining the request of the transfer and waiting for its result using `transferAndWait`.
@@ -57,7 +57,7 @@ byte bmp388_read_reg(byte const reg_addr)
   IoRequest request(read_write_buffer, sizeof(read_write_buffer), nullptr, 0);
   IoResponse response = transferAndWait(bmp388, request);
 
-  auto value = read_write_buffer[2]; 
+  auto value = read_write_buffer[2];
   return value;
 }
 ```

--- a/docs/threadsafe-wire.md
+++ b/docs/threadsafe-wire.md
@@ -20,9 +20,9 @@ while(Wire.available()) {
 ```
 Since we are using the [preemptive](https://os.mbed.com/docs/mbed-os/v6.11/program-setup/concepts.html#threads) [RTOS](https://en.wikipedia.org/wiki/Real-time_operating_system) [ARM Mbed OS](https://os.mbed.com/mbed-os/) with a tick time of 10 ms for achieving multi-tasking capability and under the assumption that all threads share the same priority (which leads to a [round-robin scheduling](https://en.wikipedia.org/wiki/Round-robin_scheduling)) it can easily happen that one thread is half-way through its `Wire` access when the scheduler interrupts it and schedules the next thread which in turn starts/continues/ends its own `Wire` access.
 
-As a result this interruption by the scheduler will break `Wire` access for both devices and leave the `Wire` controller in an undefined state. 
+As a result this interruption by the scheduler will break `Wire` access for both devices and leave the `Wire` controller in an undefined state.
 
-In Arduino Parallela we introduced the concept of `BusDevice`s which are meant to unify the way sketches access peripherals through heterogeneous busses such as `Wire`, `SPI` and `Serial`. A `BusDevice` is declared simply by specifying the type of interface and its parameters: 
+In Arduino Parallela we introduced the concept of `BusDevice`s which are meant to unify the way sketches access peripherals through heterogeneous busses such as `Wire`, `SPI` and `Serial`. A `BusDevice` is declared simply by specifying the type of interface and its parameters:
 ```C++
 BusDevice lsm6dsox(Wire, LSM6DSOX_ADDRESS);
 /* or */
@@ -31,7 +31,7 @@ BusDevice lsm6dsox(Wire, LSM6DSOX_ADDRESS, true /* restart */);
 BusDevice lsm6dsox(Wire, LSM6DSOX_ADDRESS, false /* restart */, true, /* stop */);
 ```
 
-### Asynchronous thread-safe `Wire` access with `transfer`/`wait` 
+### Asynchronous thread-safe `Wire` access with `transfer`/`wait`
 Once a `BusDevice` is declared it can be used to transfer data to and from the peripheral by means of the `transfer()` API. As opposed to the traditional Arduino bus APIs, `transfer()` is asynchronous and thus won't block execution unless the `wait()` function is called.
 Note that we are in a parallel programming environment which means that calls to `transfer()` on the same bus from different sketches will be arbitrated.
 
@@ -40,31 +40,31 @@ byte lsm6dsox_read_reg(byte const reg_addr)
 {
   byte write_buffer = reg_addr;
   byte read_buffer  = 0;
-  
+
   IoRequest  request(write_buffer, read_buffer);
   IoResponse response = lsm6dsox.transfer(request);
-  
-  /* Wait for the completion of the IO Request. 
+
+  /* Wait for the completion of the IO Request.
      Allows other threads to run */
   response->wait();
- 
+
   return read_buffer;
 }
 ```
 
-### Synchronous thread-safe `Wire` access with `transferAndWait` 
+### Synchronous thread-safe `Wire` access with `transferAndWait`
 ([`examples/Threadsafe_IO/Wire`](../examples/Threadsafe_IO/Wire))
 
-As the use of the `transfer` API might be difficult to grasp there's also a synchronous API call combining the request of the transfer and waiting for its result using `transferAndWait`. 
+As the use of the `transfer` API might be difficult to grasp there's also a synchronous API call combining the request of the transfer and waiting for its result using `transferAndWait`.
 ```C++
 byte lsm6dsox_read_reg(byte const reg_addr)
 {
   byte write_buffer = reg_addr;
   byte read_buffer  = 0;
-  
+
   IoRequest  request(write_buffer, read_buffer);
   IoResponse response = transferAndWait(lsm6dsox, request); /* Transmit IO request for execution and wait for completion of request. */
-  
+
   return read_buffer;
 }
 ```

--- a/examples/Threading_Basics/Source_Sink_Counter/Source_Sink_Counter.ino
+++ b/examples/Threading_Basics/Source_Sink_Counter/Source_Sink_Counter.ino
@@ -1,4 +1,4 @@
-/* This examples demonstrates the SOURCE/SINK abstraction. Each thread
+/* This example demonstrates the SOURCE/SINK abstraction. Each thread
  * may have any number of SOURCES and SINKS that can be connected
  * together using the 'connectTo' method.
  */

--- a/examples/Threading_Basics/Source_Sink_LED/Source_Sink_LED.ino
+++ b/examples/Threading_Basics/Source_Sink_LED/Source_Sink_LED.ino
@@ -1,4 +1,4 @@
-/* This examples demonstrates the SOURCE/SINK abstraction. Each thread
+/* This example demonstrates the SOURCE/SINK abstraction. Each thread
  * may have any number of SOURCES and SINKS that can be connected
  * together using the 'connectTo' method.
  */

--- a/examples/Threading_Basics/Thermostat/AirConditionerControl.inot
+++ b/examples/Threading_Basics/Thermostat/AirConditionerControl.inot
@@ -32,7 +32,7 @@ void loop()
   if (is_ac_on && turn_ac_off)
   {
     is_ac_on = false;
-  
+
     Serial.block();
     Serial.print("AC OFF (");
     Serial.print(current_temperature_deg);
@@ -43,7 +43,7 @@ void loop()
   if (!is_ac_on && turn_ac_on)
   {
     is_ac_on = true;
-    
+
     Serial.block();
     Serial.print("AC ON  (");
     Serial.print(current_temperature_deg);

--- a/examples/Threading_Basics/Thermostat/HeatingControl.inot
+++ b/examples/Threading_Basics/Thermostat/HeatingControl.inot
@@ -32,7 +32,7 @@ void loop()
   if (is_heating_on && turn_heating_off)
   {
     is_heating_on = false;
-  
+
     Serial.block();
     Serial.print("Heating OFF (");
     Serial.print(current_temperature_deg);
@@ -43,7 +43,7 @@ void loop()
   if (!is_heating_on && turn_heating_on)
   {
     is_heating_on = true;
-    
+
     Serial.block();
     Serial.print("Heating ON (");
     Serial.print(current_temperature_deg);

--- a/examples/Threading_Basics/Thermostat/TemperatureSensor.inot
+++ b/examples/Threading_Basics/Thermostat/TemperatureSensor.inot
@@ -9,11 +9,11 @@ void setup()
 void loop()
 {
   /* Read temperature - since this is just a simulation
-   * so we take a random value between 15 and 30 °C.
+   * we take a random value between 15 and 30 °C.
    */
   float const temperature_deg = (rand() % 16) + 15;
   /* Store in temperature source variable. */
   temperature.push(temperature_deg);
-  /* Do only one temperature sensore measurement per second. */
+  /* Do only one temperature sensor measurement per second. */
   delay(5000);
 }

--- a/examples/Threading_Basics/Thermostat/Thermostat.ino
+++ b/examples/Threading_Basics/Thermostat/Thermostat.ino
@@ -1,10 +1,10 @@
 /* This example emulates a thermostat system which consists of
- * a single temperature sensore and multiple heating devices
+ * a single temperature sensor and multiple heating devices
  * or air-conditioners. The temperature sensor provides periodic
  * temperature sensor measurements and acts as a temperature source.
  * This temperature is consumed by various TemperatureControl_ threads
  * which perform the act of actual room temperature control.
- * 
+ *
  * Note: While there is only a single temperature "source" there are
  * multiple temperature "sinks". The source/sink paradigm is constructed
  * in such a way, that each sink is guaranteed to see every value provided

--- a/examples/Threadsafe_IO/SPI/SPI.ino
+++ b/examples/Threadsafe_IO/SPI/SPI.ino
@@ -86,7 +86,7 @@ void bmp388_thread_func()
     rtos::ThisThread::sleep_for(rtos::Kernel::Clock::duration_u32(random(5,500)));
     /* Try to read some data from the BMP3888. */
     byte const chip_id = bmp388_read_reg(BMP388_CHIP_ID_REG_ADDR);
-    /* Print thread id and chip id value to serial. */
+    /* Print thread ID and chip ID value to serial. */
     char msg[64] = {0};
     snprintf(msg, sizeof(msg), "%s: Chip ID = 0x%X", rtos::ThisThread::get_name(), chip_id);
     Serial.println(msg);

--- a/examples/Threadsafe_IO/SPI_BusIO/SPI_BusIO.ino
+++ b/examples/Threadsafe_IO/SPI_BusIO/SPI_BusIO.ino
@@ -85,7 +85,7 @@ void bmp388_thread_func()
     rtos::ThisThread::sleep_for(rtos::Kernel::Clock::duration_u32(random(5,500)));
     /* Try to read some data from the BMP3888. */
     byte const chip_id = bmp388_read_reg(BMP388_CHIP_ID_REG_ADDR);
-    /* Print thread id and chip id value to serial. */
+    /* Print thread ID and chip ID value to serial. */
     char msg[64] = {0};
     snprintf(msg, sizeof(msg), "%s: Chip ID = 0x%X", rtos::ThisThread::get_name(), chip_id);
     Serial.println(msg);

--- a/examples/Threadsafe_IO/Serial_Reader/Serial_Reader.ino
+++ b/examples/Threadsafe_IO/Serial_Reader/Serial_Reader.ino
@@ -35,7 +35,7 @@ void loop()
   while (Serial.available())
     serial_msg += (char)Serial.read();
 
-  /* Print thread id and chip id value to serial. */
+  /* Print thread ID and chip ID value to serial. */
   if (serial_msg.length())
   {
     Serial.block();

--- a/examples/Threadsafe_IO/Serial_Reader/Thread_1.inot
+++ b/examples/Threadsafe_IO/Serial_Reader/Thread_1.inot
@@ -14,7 +14,7 @@ void loop()
   while (Serial.available())
     serial_msg += (char)Serial.read();
 
-  /* Print thread id and chip id value to serial. */
+  /* Print thread ID and chip ID value to serial. */
   if (serial_msg.length())
   {
     Serial.block();

--- a/examples/Threadsafe_IO/Serial_Reader/Thread_2.inot
+++ b/examples/Threadsafe_IO/Serial_Reader/Thread_2.inot
@@ -14,7 +14,7 @@ void loop()
   while (Serial.available())
     serial_msg += (char)Serial.read();
 
-  /* Print thread id and chip id value to serial. */
+  /* Print thread ID and chip ID value to serial. */
   if (serial_msg.length())
   {
     Serial.block();

--- a/examples/Threadsafe_IO/Serial_Reader/Thread_3.inot
+++ b/examples/Threadsafe_IO/Serial_Reader/Thread_3.inot
@@ -14,7 +14,7 @@ void loop()
   while (Serial.available())
     serial_msg += (char)Serial.read();
 
-  /* Print thread id and chip id value to serial. */
+  /* Print thread ID and chip ID value to serial. */
   if (serial_msg.length())
   {
     Serial.block();

--- a/examples/Threadsafe_IO/Wire/Wire.ino
+++ b/examples/Threadsafe_IO/Wire/Wire.ino
@@ -65,10 +65,10 @@ byte lsm6dsox_read_reg(byte const reg_addr)
    */
   byte write_buf = reg_addr;
   byte read_buf  = 0;
-  
+
   IoRequest  req(write_buf, read_buf);
   IoResponse rsp = transferAndWait(lsm6dsox, req);
-  
+
   return read_buf;
 }
 
@@ -84,7 +84,7 @@ void lsm6dsox_thread_func()
     rtos::ThisThread::sleep_for(rtos::Kernel::Clock::duration_u32(random(5,500)));
     /* Try to read some data from the LSM6DSOX. */
     byte const who_am_i = lsm6dsox_read_reg(LSM6DSOX_WHO_AM_I_REG);
-    /* Print thread id and chip id value to serial. */
+    /* Print thread ID and chip ID value to serial. */
     char msg[64] = {0};
     snprintf(msg, sizeof(msg), "%s: LSM6DSOX[WHO_AM_I] = 0x%X", rtos::ThisThread::get_name(), who_am_i);
     Serial.println(msg);

--- a/examples/Threadsafe_IO/Wire_BusIO/Wire_BusIO.ino
+++ b/examples/Threadsafe_IO/Wire_BusIO/Wire_BusIO.ino
@@ -79,7 +79,7 @@ void lsm6dsox_thread_func()
     rtos::ThisThread::sleep_for(rtos::Kernel::Clock::duration_u32(random(5,500)));
     /* Try to read some data from the LSM6DSOX. */
     byte const who_am_i = lsm6dsox_read_reg(LSM6DSOX_WHO_AM_I_REG);
-    /* Print thread id and chip id value to serial. */
+    /* Print thread ID and chip ID value to serial. */
     char msg[64] = {0};
     snprintf(msg, sizeof(msg), "%s: LSM6DSOX[WHO_AM_I] = 0x%X", rtos::ThisThread::get_name(), who_am_i);
     Serial.println(msg);

--- a/src/io/serial/SerialDispatcher.cpp
+++ b/src/io/serial/SerialDispatcher.cpp
@@ -77,7 +77,7 @@ void SerialDispatcher::end()
 {
   mbed::ScopedLock<rtos::Mutex> lock(_mutex);
 
-  /* Retrieve the current thread id and remove
+  /* Retrieve the current thread ID and remove
    * the thread data from the thread data list.
    */
   osThreadId_t const current_thread_id = rtos::ThisThread::get_id();
@@ -297,7 +297,7 @@ void SerialDispatcher::threadFunc()
 
 std::list<SerialDispatcher::ThreadCustomerData>::iterator SerialDispatcher::findThreadCustomerDataById(osThreadId_t const thread_id)
 {
-  return std::find_if(std::begin(_thread_customer_list), 
+  return std::find_if(std::begin(_thread_customer_list),
                       std::end  (_thread_customer_list),
                       [thread_id](ThreadCustomerData const d) -> bool
                       {

--- a/src/io/spi/SpiDispatcher.cpp
+++ b/src/io/spi/SpiDispatcher.cpp
@@ -141,7 +141,7 @@ void SpiDispatcher::processSpiIoRequest(SpiIoTransaction * spi_io_transaction)
   config->spi().beginTransaction(config->settings());
 
   /* In a first step transmit the complete write buffer and
-   * write back the receive data directly into the write buffer  
+   * write back the receive data directly into the write buffer
    */
   size_t bytes_sent = 0;
   for(; bytes_sent < io_request->bytes_to_write; bytes_sent++)


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) spellchecker tool is used to automatically detect commonly misspelled words in the files of this project.

The misspelled words dictionary was expanded in the [latest release](https://github.com/codespell-project/codespell/releases/tag/v2.4.0) of codespell, which resulted in the detection of a
misspelled word in the project's documentation:

https://github.com/arduino-libraries/Arduino_Threads/actions/runs/13005983050/job/36272909846#step:4:17

```text
Error: ./docs/threadsafe-serial.md:51: pre-emptive ==> preemptive
Codespell found one or more problems
```

The typo is hereby corrected, which will restore the spell check to a passing state.

---

I supplemented the correction of the automatically detected typo with a general review of the documentation content, fixing the additional typos I identified during that review.